### PR TITLE
Change default subnet from devnet-beta.1 to devnet-beta.2

### DIFF
--- a/requestor.py
+++ b/requestor.py
@@ -97,6 +97,7 @@ async def main():
             payload=package,
             timeout=TASK_TIMEOUT
         ):
+            # Every task object we receive here represents a computed task
             if task.result:
                 result = task.result
                 # Exit early once a matching word is found

--- a/requestor.py
+++ b/requestor.py
@@ -24,7 +24,7 @@ import worker
 # CLI arguments definition
 arg_parser = argparse.ArgumentParser()
 arg_parser.add_argument("--hash", type=Path, default=Path("data/hash.json"))
-arg_parser.add_argument("--subnet", type=str, default="devnet-beta.1")
+arg_parser.add_argument("--subnet", type=str, default="devnet-beta.2")
 arg_parser.add_argument("--words", type=Path, default=Path("data/words.txt"))
 
 # Container object for parsed arguments

--- a/requestor.py
+++ b/requestor.py
@@ -87,9 +87,9 @@ async def main():
         min_storage_gib=2.0,
     )
 
-    result = ""
-
     async with Golem(budget=1, subnet_tag=args.subnet) as golem:
+
+        result = ""
 
         async for task in golem.execute_tasks(
             steps,
@@ -102,10 +102,10 @@ async def main():
                 # Exit early once a matching word is found
                 break
 
-    if result:
-        print(f"Found matching word: {result}")
-    else:
-        print("No matching words found.")
+        if result:
+            print(f"Found matching word: {result}")
+        else:
+            print("No matching words found.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I've also squeezed in another change, moving the definition of `result` and the code that prints it inside the scope of `async with Golem(...)`. I think it's a bit more readable and closer to the original code (and hence requires less changes in the handbook).