### PR TITLE
Make the example compatible with Windows

### DIFF
--- a/requestor.py
+++ b/requestor.py
@@ -30,7 +30,7 @@ arg_parser.add_argument("--words", type=Path, default=Path("data/words.txt"))
 # Container object for parsed arguments
 args = argparse.Namespace()
 
-ENTRYPOINT_PATH = Path("/golem/entrypoint/worker.py")
+ENTRYPOINT_PATH = "/golem/entrypoint/worker.py"
 TASK_TIMEOUT = timedelta(minutes=10)
 
 
@@ -59,16 +59,16 @@ async def steps(context: WorkContext, tasks: AsyncIterable[Task]):
     Tasks are provided from a common, asynchronous queue.
     The signature of this function cannot change, as it's used internally by `Executor`.
     """
-    context.send_file(str(args.hash), str(worker.HASH_PATH))
+    context.send_file(str(args.hash), worker.HASH_PATH)
 
     async for task in tasks:
-        context.send_json(str(worker.WORDS_PATH), task.data)
+        context.send_json(worker.WORDS_PATH, task.data)
 
-        context.run(str(ENTRYPOINT_PATH))
+        context.run(ENTRYPOINT_PATH)
 
         # Create a temporary file to avoid overwriting incoming results
         output_file = NamedTemporaryFile()
-        context.download_file(str(worker.RESULT_PATH), output_file.name)
+        context.download_file(worker.RESULT_PATH, output_file.name)
 
         # Pass the prepared sequence of steps to Executor
         yield context.commit()

--- a/requestor.py
+++ b/requestor.py
@@ -98,10 +98,7 @@ async def main():
         result = ""
 
         async for task in golem.execute_tasks(
-            steps,
-            data(args.words),
-            payload=package,
-            timeout=TASK_TIMEOUT
+            steps, data(args.words), payload=package, timeout=TASK_TIMEOUT
         ):
             # Every task object we receive here represents a computed task
             if task.result:

--- a/worker.py
+++ b/worker.py
@@ -11,17 +11,17 @@ from typing import List
 
 ENCODING = "utf-8"
 
-HASH_PATH = Path("/golem/input/hash.json")
-WORDS_PATH = Path("/golem/input/words.json")
-RESULT_PATH = Path("/golem/output/result.json")
+HASH_PATH = "/golem/input/hash.json"
+WORDS_PATH = "/golem/input/words.json"
+RESULT_PATH = "/golem/output/result.json"
 
 if __name__ == "__main__":
     result = ""
 
-    with HASH_PATH.open() as f:
+    with open(HASH_PATH) as f:
         target_hash: str = json.load(f)
 
-    with WORDS_PATH.open() as f:
+    with open(WORDS_PATH) as f:
         words: List[str] = json.load(f)
         for line in words:
             line_bytes = bytes(line.strip(), ENCODING)
@@ -30,5 +30,5 @@ if __name__ == "__main__":
                 result = line
                 break
 
-    with RESULT_PATH.open(mode="w", encoding=ENCODING) as f:
+    with open(RESULT_PATH, mode='w', encoding=ENCODING) as f:
         json.dump(result, f)

--- a/worker.py
+++ b/worker.py
@@ -30,5 +30,5 @@ if __name__ == "__main__":
                 result = line
                 break
 
-    with open(RESULT_PATH, mode='w', encoding=ENCODING) as f:
+    with open(RESULT_PATH, mode="w", encoding=ENCODING) as f:
         json.dump(result, f)


### PR DESCRIPTION
In its current form, this example does not work on Windows hosts (as explained here: https://github.com/krunch3r76/hash-cracker).
This PR aims to address two main issues:
- `pathlib.Path` instances, when converted to a string, inherit their path style from the host OS. This means that using them for paths within the VM will not work on systems with paths schemes different from Unix ones (e.g. Windows).
- `tempfile.NamedTemporaryFile` is known to cause problems on Windows, since creating an instance of this class also opens the target file. This turns out to be a problem on Windows, as it does not allow opening multiple file handles (even read-only ones) to a single file.